### PR TITLE
Use lodash's get() to allow for nested field values in constraints

### DIFF
--- a/lib/csvBuilder.js
+++ b/lib/csvBuilder.js
@@ -189,7 +189,7 @@ CsvBuilder.prototype._buildRowArray = function(obj) {
     obj[prop] = _virtuals[prop](obj);
   }
   for (var i = 0; i < hlen; i++) {
-    row[i] = obj[(_constraints[_headers[i]] || _headers[i])] || '';
+    row[i] = _.get(obj, (_constraints[_headers[i]] || _headers[i]), '');
   }
   return row;
 };


### PR DESCRIPTION
Here's the feature: by using [lodash's get()](https://lodash.com/docs/3.10.1#get) instead of the bracket accessor syntax ( `[]` ), we can easily use a path matching nested properties in the source objects.

So if you have the following source object:
```
{
  "name": "Kamryn Rempel",
  "age": 48,
  "email": "Fabian.Ernser54@gmail.com",
  "meta": {
    "active": true
  }
}
```
then we can have a constraint config object like so:
```
{
  "Name": "name",
  "Age": "age",
  "Email": "email",
  "Active": "meta.active"
}
```